### PR TITLE
Add safety car and red flag statistics to historical F1 data

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}\\index.js"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Node.js application that fetches Formula 1 race information from multiple APIs
 
 - Fetches next race details (circuit info, session times, location)
 - Determines weekend format (regular/sprint)
-- Collects historical race data (winners and finishers) for the last decade
+- Collects historical race data (winners, finishers, safety car deployments, and red flags) for the last decade
 - Outputs structured JSON data to Azure Blob Storage
 - Logs the JSON output to the console
 - Runs in a containerized environment
@@ -154,7 +154,10 @@ The application generates a JSON file with the following structure (uploaded as 
     {
       "season": number,
       "winner": "string",
-      "carsFinished": number
+      "constructor": "string",
+      "carsFinished": number,
+      "safetyCars": number, // Optional
+      "redFlags": number    // Optional
     }
   ]
 }
@@ -168,70 +171,89 @@ Here's an example output for the Monaco Grand Prix:
 
 ```json
 {
-  "circuitId": "monaco",
-  "raceName": "Monaco Grand Prix",
-  "round": 8,
+  "circuitId": "catalunya",
+  "raceName": "Spanish Grand Prix",
+  "round": 9,
   "season": 2025,
-  "circuitName": "Circuit de Monaco",
+  "circuitName": "Circuit de Barcelona-Catalunya",
   "location": {
-    "lat": "43.7347",
-    "long": "7.42056",
-    "locality": "Monte-Carlo",
-    "country": "Monaco"
+    "lat": "41.57",
+    "long": "2.26111",
+    "locality": "Montmeló",
+    "country": "Spain"
   },
   "sessions": {
-    "firstPractice": "2025-05-23T11:30:00Z",
-    "secondPractice": "2025-05-23T15:00:00Z",
-    "thirdPractice": "2025-05-24T10:30:00Z",
-    "qualifying": "2025-05-24T14:00:00Z",
-    "race": "2025-05-25T13:00:00Z"
+    "firstPractice": "2025-05-30T11:30:00Z",
+    "secondPractice": "2025-05-30T15:00:00Z",
+    "thirdPractice": "2025-05-31T10:30:00Z",
+    "qualifying": "2025-05-31T14:00:00Z",
+    "race": "2025-06-01T13:00:00Z"
   },
   "weekendFormat": "regular",
   "historicalData": [
     {
-      "season": 2015,
-      "winner": "Nico Rosberg",
-      "carsFinished": 17
-    },
-    {
-      "season": 2016,
-      "winner": "Lewis Hamilton",
-      "carsFinished": 15
-    },
-    {
-      "season": 2017,
-      "winner": "Sebastian Vettel",
-      "carsFinished": 13
-    },
-    {
-      "season": 2018,
-      "winner": "Daniel Ricciardo",
-      "carsFinished": 17
-    },
-    {
-      "season": 2019,
-      "winner": "Lewis Hamilton",
-      "carsFinished": 19
-    },
-    {
-      "season": 2021,
+      "season": 2024,
       "winner": "Max Verstappen",
-      "carsFinished": 18
-    },
-    {
-      "season": 2022,
-      "winner": "Sergio Pérez",
-      "carsFinished": 17
+      "constructor": "Red Bull",
+      "carsFinished": 20,
+      "safetyCars": 0,
+      "redFlags": 0
     },
     {
       "season": 2023,
       "winner": "Max Verstappen",
+      "constructor": "Red Bull",
+      "carsFinished": 20,
+      "safetyCars": 0,
+      "redFlags": 0
+    },
+    {
+      "season": 2022,
+      "winner": "Max Verstappen",
+      "constructor": "Red Bull",
+      "carsFinished": 18
+    },
+    {
+      "season": 2021,
+      "winner": "Lewis Hamilton",
+      "constructor": "Mercedes",
       "carsFinished": 19
     },
     {
-      "season": 2024,
-      "winner": "Charles Leclerc",
+      "season": 2020,
+      "winner": "Lewis Hamilton",
+      "constructor": "Mercedes",
+      "carsFinished": 19
+    },
+    {
+      "season": 2019,
+      "winner": "Lewis Hamilton",
+      "constructor": "Mercedes",
+      "carsFinished": 18
+    },
+    {
+      "season": 2018,
+      "winner": "Lewis Hamilton",
+      "constructor": "Mercedes",
+      "carsFinished": 14
+    },
+    {
+      "season": 2017,
+      "winner": "Lewis Hamilton",
+      "constructor": "Mercedes",
       "carsFinished": 16
+    },
+    {
+      "season": 2016,
+      "winner": "Max Verstappen",
+      "constructor": "Red Bull",
+      "carsFinished": 17
+    },
+    {
+      "season": 2015,
+      "winner": "Nico Rosberg",
+      "constructor": "Mercedes",
+      "carsFinished": 18
     }
   ]
 }
@@ -242,6 +264,7 @@ Here's an example output for the Monaco Grand Prix:
 - `index.js` - Main application logic
 - `src/azureBlobStorageService.js` - Azure Blob Storage upload logic
 - `src/f1DataService.js` - F1 data fetching and processing
+  - Includes `fetchRaceInterruptionData` for safety car and red flag statistics
 - `package.json` - Project configuration
 - `Dockerfile` - Container configuration
 - `.dockerignore` - Docker build exclusions

--- a/src/f1DataService.js
+++ b/src/f1DataService.js
@@ -1,10 +1,11 @@
 // Fetch data from the F1 APIs and generate JSON output
 
+const JOLPI_API_BASE = 'https://api.jolpi.ca/ergast/f1';
+const OPENF1_API_BASE = 'https://api.openf1.org';
+
 async function fetchNextRaceData() {
   try {
-    const response = await fetch(
-      'https://api.jolpi.ca/ergast/f1/current/next.json',
-    );
+    const response = await fetch(`${JOLPI_API_BASE}/current/next.json`);
     if (!response.ok) {
       throw new Error(`Failed to fetch next race data: ${response.status}`);
     }
@@ -61,7 +62,7 @@ async function fetchNextRaceData() {
 async function checkSprintWeekend(season, round) {
   try {
     const response = await fetch(
-      `https://api.jolpi.ca/ergast/f1/${season}/${round}/sprint.json`,
+      `${JOLPI_API_BASE}/${season}/${round}/sprint.json`,
     );
     if (!response.ok) {
       throw new Error(`Failed to fetch sprint data: ${response.status}`);
@@ -76,6 +77,82 @@ async function checkSprintWeekend(season, round) {
   }
 }
 
+/**
+ * Fetches the number of safety car deployments (regular and virtual) and red flags
+ * for a given year and race name using the OpenF1 API.
+ * - Safety cars: Counts messages with category=SafetyCar containing "DEPLOYED" (case-insensitive).
+ * - Red flags: Counts messages with flag=RED.
+ */
+async function fetchRaceInterruptionData(year, raceName) {
+  const meetingsUrl = `${OPENF1_API_BASE}/v1/meetings?meeting_name=${encodeURIComponent(raceName)}&year=${year}`;
+  let meetingKey = null;
+
+  try {
+    const meetingsResp = await fetch(meetingsUrl);
+    if (!meetingsResp.ok) return { safetyCarDeployments: null, redFlags: null };
+    const meetings = await meetingsResp.json();
+
+    // Normalize and match meeting_name to raceName
+    const meeting = meetings.find(
+      (m) =>
+        m.meeting_name &&
+        m.meeting_name.toLowerCase().includes(raceName.toLowerCase()),
+    );
+    if (!meeting) return { safetyCarDeployments: null, redFlags: null };
+    meetingKey = meeting.meeting_key;
+  } catch {
+    return { safetyCarDeployments: null, redFlags: null };
+  }
+
+  // Fetch session_key for the Race session
+  let sessionKey = null;
+  try {
+    const sessionUrl = `${OPENF1_API_BASE}/v1/sessions?meeting_key=${meetingKey}&session_name=Race`;
+    const sessionResp = await fetch(sessionUrl);
+    if (!sessionResp.ok) return { safetyCarDeployments: null, redFlags: null };
+    const sessions = await sessionResp.json();
+    if (!Array.isArray(sessions) || sessions.length === 0)
+      return { safetyCarDeployments: null, redFlags: null };
+    // Find the session with session_name === "Race"
+    const raceSession = sessions.find((s) => s.session_name === 'Race');
+    if (!raceSession || !raceSession.session_key)
+      return { safetyCarDeployments: null, redFlags: null };
+    sessionKey = raceSession.session_key;
+  } catch {
+    return { safetyCarDeployments: null, redFlags: null };
+  }
+
+  // Fetch all Safety Car deployments (regular and virtual) by category only, using session_key
+  let safetyCarDeployments = 0;
+  try {
+    const scUrl = `${OPENF1_API_BASE}/v1/race_control?session_key=${sessionKey}&category=SafetyCar`;
+    const scResp = await fetch(scUrl);
+    if (scResp.ok) {
+      const scMsgs = await scResp.json();
+      safetyCarDeployments = scMsgs.filter(
+        (msg) => msg.message && msg.message.toUpperCase().includes('DEPLOYED'),
+      ).length;
+    }
+  } catch (err) {
+    console.warn('Error fetching Safety Car deployments:', err);
+  }
+
+  // Fetch red flags using flag=RED
+  let redFlags = null;
+  try {
+    const rfUrl = `${OPENF1_API_BASE}/v1/race_control?session_key=${sessionKey}&flag=RED`;
+    const rfResp = await fetch(rfUrl);
+    if (rfResp.ok) {
+      const rfMsgs = await rfResp.json();
+      redFlags = Array.isArray(rfMsgs) ? rfMsgs.length : null;
+    }
+  } catch (err) {
+    console.warn('Error fetching Red Flags:', err);
+  }
+
+  return { safetyCarDeployments, redFlags };
+}
+
 async function fetchHistoricalResults(circuitId) {
   try {
     const currentYear = new Date().getFullYear();
@@ -85,7 +162,7 @@ async function fetchHistoricalResults(circuitId) {
 
     for (let year = startYear; year <= endYear; year++) {
       const response = await fetch(
-        `https://api.jolpi.ca/ergast/f1/${year}/circuits/${circuitId}/results.json`,
+        `${JOLPI_API_BASE}/${year}/circuits/${circuitId}/results.json`,
       );
       if (!response.ok) {
         console.warn(`No data available for ${year}`);
@@ -99,6 +176,7 @@ async function fetchHistoricalResults(circuitId) {
         // Get the winner (first position)
         const winner = race.Results[0].Driver;
         const winnerName = `${winner.givenName} ${winner.familyName}`;
+        const constructor = race.Results[0].Constructor.name;
 
         // Count finished cars (including those that completed the race but weren't on the lead lap)
         const finishedCars = race.Results.filter(
@@ -106,15 +184,45 @@ async function fetchHistoricalResults(circuitId) {
             result.status === 'Finished' || result.status.includes('Lap'),
         ).length;
 
-        results.push({
+        // Fetch total SC/VSC deployments from OpenF1 using year and raceName
+        let safetyCarDeployments = null;
+        let redFlags = null;
+        if (race.raceName) {
+          try {
+            const interruptionData = await fetchRaceInterruptionData(
+              year,
+              race.raceName,
+            );
+            safetyCarDeployments = interruptionData.safetyCarDeployments;
+            redFlags = interruptionData.redFlags;
+          } catch (err) {
+            console.warn(
+              `Failed to fetch race interruption data for ${year} ${race.raceName}`,
+            );
+          }
+        }
+
+        const resultObj = {
           season: year,
           winner: winnerName,
+          constructor,
           carsFinished: finishedCars,
-        });
+        };
+        if (
+          safetyCarDeployments !== null &&
+          safetyCarDeployments !== undefined
+        ) {
+          resultObj.safetyCars = safetyCarDeployments;
+        }
+        if (redFlags !== null && redFlags !== undefined) {
+          resultObj.redFlags = redFlags;
+        }
+        results.push(resultObj);
       }
     }
 
-    return results;
+    // Order results by year descending
+    return results.sort((a, b) => b.season - a.season);
   } catch (error) {
     console.error('Error fetching historical results:', error);
     throw error;
@@ -143,4 +251,5 @@ module.exports = {
   checkSprintWeekend,
   fetchHistoricalResults,
   fetchAllF1Data,
+  fetchRaceInterruptionData,
 };


### PR DESCRIPTION
- Integrate OpenF1 API to fetch safety car deployments and red flags per race
- Update fetchHistoricalResults to include constructor, safetyCars, and redFlags fields
- Add fetchRaceInterruptionData utility for race interruptions
- Update README with new data structure and example output
- Add VSCode launch configuration for Node.js debugging