### PR TITLE
Add circuit image to race info JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A Node.js application that fetches Formula 1 race information from multiple APIs
 ## Features
 
 - Fetches next race details (circuit info, session times, location)
+- Retrieves the circuit image URL from Wikipedia
 - Determines weekend format (regular/sprint)
 - Collects historical race data (winners, pole positions, podium finishers, safety car deployments, red flags, and overtakes) for the last decade
 - Integrates overtake data from external Google Sheets source
@@ -166,6 +167,7 @@ The application generates a JSON file with the following structure (uploaded as 
   "round": 9,
   "season": 2025,
   "circuitName": "Circuit de Barcelona-Catalunya",
+  "circuitImageUrl": "https://upload.wikimedia.org/wikipedia/commons/6/65/Circuit_de_Barcelona-Catalunya_layout.svg",
   "location": {
     "lat": "41.57",
     "long": "2.26111",


### PR DESCRIPTION
## Summary
- fetch the track image from Wikipedia
- include `circuitImageUrl` in the next race data
- document the new `circuitImageUrl` field in README

## Testing
- `npm run lint`
- `node index.js` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_688c80b024d0832fa09524a7a4a85e38