### PR TITLE
Extract Wikipedia circuit image service

### DIFF
--- a/src/f1DataService.js
+++ b/src/f1DataService.js
@@ -3,32 +3,10 @@
 const JOLPI_API_BASE = 'https://api.jolpi.ca/ergast/f1';
 const OPENF1_API_BASE = 'https://api.openf1.org';
 const { getTrackHistoricalInfo } = require('./azureOpenAiService');
+const { fetchCircuitImage } = require('./wikipediaCircuitImageService');
 const MIN_RACE_INTERRUPTION_YEAR = 2023;
 const OPENF1_REQUEST_DELAY_MS = 2500;
 const OPENF1_429_RETRY_DELAY_MS = 5000;
-
-async function fetchCircuitImage(wikipediaUrl) {
-  if (!wikipediaUrl) return null;
-
-  try {
-    const pageTitle = wikipediaUrl.split('/wiki/')[1];
-    if (!pageTitle) return null;
-
-    const apiUrl = `https://en.wikipedia.org/w/api.php?action=query&titles=${pageTitle}&prop=pageimages&format=json&pithumbsize=1000`;
-    const response = await fetch(apiUrl);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch circuit image: ${response.status}`);
-    }
-
-    const data = await response.json();
-    const pages = data.query?.pages;
-    const firstPage = pages ? pages[Object.keys(pages)[0]] : null;
-    return firstPage?.thumbnail?.source || null;
-  } catch (err) {
-    console.warn('Failed to fetch circuit image:', err);
-    return null;
-  }
-}
 
 // Languages supported for track history generation
 const SUPPORTED_LANGUAGES = [
@@ -365,7 +343,6 @@ module.exports = {
   fetchAllF1Data,
   fetchRaceInterruptionData,
   fetchOvertakeData,
-  fetchCircuitImage,
 };
 
 /**

--- a/src/wikipediaCircuitImageService.js
+++ b/src/wikipediaCircuitImageService.js
@@ -1,4 +1,5 @@
 const WIKIPEDIA_API_BASE = 'https://en.wikipedia.org/w/api.php';
+const CIRCUIT_IMAGE_WIDTH = '1000';
 const { sendTelegramMessage } = require('./telegramService');
 
 async function fetchCircuitImage(wikipediaUrl) {
@@ -114,11 +115,12 @@ async function fetchWikipediaImageUrl(imageName) {
     titles: `File:${imageName}`,
     prop: 'imageinfo',
     iiprop: 'url',
+    iiurlwidth: CIRCUIT_IMAGE_WIDTH,
     redirects: '1',
   });
 
   const firstPage = getFirstWikipediaQueryPage(data);
-  return firstPage?.imageinfo?.[0]?.url || null;
+  return firstPage?.imageinfo?.[0]?.thumburl || null;
 }
 
 async function fetchWikipediaThumbnail(pageTitle) {

--- a/src/wikipediaCircuitImageService.js
+++ b/src/wikipediaCircuitImageService.js
@@ -1,0 +1,158 @@
+const WIKIPEDIA_API_BASE = 'https://en.wikipedia.org/w/api.php';
+const { sendTelegramMessage } = require('./telegramService');
+
+async function fetchCircuitImage(wikipediaUrl) {
+  if (!wikipediaUrl) return null;
+
+  try {
+    const pageTitle = getWikipediaPageTitle(wikipediaUrl);
+    if (!pageTitle) return null;
+
+    const imageFilename = await fetchCircuitImageFilenameFromInfobox(pageTitle);
+    if (imageFilename) {
+      const imageUrl = await fetchWikipediaImageUrl(imageFilename);
+      if (imageUrl) {
+        return imageUrl;
+      }
+    }
+
+    const thumbnailUrl = await fetchWikipediaThumbnail(pageTitle);
+    if (thumbnailUrl) {
+      return thumbnailUrl;
+    }
+
+    await notifyCircuitImageFetchFailure(
+      wikipediaUrl,
+      'No infobox image or Wikipedia thumbnail was available.',
+    );
+    return null;
+  } catch (err) {
+    console.warn('Failed to fetch circuit image:', err);
+    await notifyCircuitImageFetchFailure(wikipediaUrl, err.message);
+    return null;
+  }
+}
+
+async function notifyCircuitImageFetchFailure(wikipediaUrl, reason) {
+  await sendTelegramMessage(
+    `Warning: Failed to fetch circuit image URL for ${wikipediaUrl}. Reason: ${reason}`,
+  );
+}
+
+function getWikipediaPageTitle(wikipediaUrl) {
+  try {
+    const parsedUrl = new URL(wikipediaUrl);
+    const wikiPathPrefix = '/wiki/';
+    if (!parsedUrl.pathname.startsWith(wikiPathPrefix)) {
+      return null;
+    }
+
+    return decodeURIComponent(parsedUrl.pathname.slice(wikiPathPrefix.length));
+  } catch {
+    return null;
+  }
+}
+
+async function fetchCircuitImageFilenameFromInfobox(pageTitle) {
+  const data = await fetchWikipediaJson({
+    action: 'parse',
+    page: pageTitle,
+    prop: 'wikitext',
+    redirects: '1',
+  });
+
+  const wikitext = data.parse?.wikitext?.['*'];
+  return (
+    getInfoboxFileName(wikitext, 'image') ||
+    getInfoboxFileName(wikitext, 'track_map')
+  );
+}
+
+function getInfoboxFileName(wikitext, fieldName) {
+  if (!wikitext || !fieldName) {
+    return null;
+  }
+
+  const fieldPattern = new RegExp(
+    `\\|\\s*${fieldName}\\s*=\\s*([^\\n\\r]+)`,
+    'i',
+  );
+  const match = wikitext.match(fieldPattern);
+  if (!match) {
+    return null;
+  }
+
+  return normalizeWikipediaFileName(match[1]);
+}
+
+function normalizeWikipediaFileName(rawValue) {
+  if (!rawValue) {
+    return null;
+  }
+
+  const cleanedValue = rawValue
+    .replace(/<!--.*?-->/g, '')
+    .replace(/\{\{!}}/g, '|')
+    .trim();
+
+  const fileLinkMatch = cleanedValue.match(
+    /\[\[(?:File|Image):([^|\]]+\.(?:svg|png|jpe?g|webp|gif))/i,
+  );
+  if (fileLinkMatch) {
+    return fileLinkMatch[1].trim().replace(/ /g, '_');
+  }
+
+  const fileNameMatch = cleanedValue.match(
+    /([^|<>{}[\]]+\.(?:svg|png|jpe?g|webp|gif))/i,
+  );
+  return fileNameMatch ? fileNameMatch[1].trim().replace(/ /g, '_') : null;
+}
+
+async function fetchWikipediaImageUrl(imageName) {
+  const data = await fetchWikipediaJson({
+    action: 'query',
+    titles: `File:${imageName}`,
+    prop: 'imageinfo',
+    iiprop: 'url',
+    redirects: '1',
+  });
+
+  const firstPage = getFirstWikipediaQueryPage(data);
+  return firstPage?.imageinfo?.[0]?.url || null;
+}
+
+async function fetchWikipediaThumbnail(pageTitle) {
+  const data = await fetchWikipediaJson({
+    action: 'query',
+    titles: pageTitle,
+    prop: 'pageimages',
+    pithumbsize: '1000',
+    redirects: '1',
+  });
+
+  const firstPage = getFirstWikipediaQueryPage(data);
+  return firstPage?.thumbnail?.source || null;
+}
+
+async function fetchWikipediaJson(params) {
+  const apiUrl = `${WIKIPEDIA_API_BASE}?${new URLSearchParams({
+    ...params,
+    format: 'json',
+  }).toString()}`;
+  const response = await fetch(apiUrl);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Wikipedia data: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+function getFirstWikipediaQueryPage(data) {
+  const pages = data.query?.pages;
+  return pages ? pages[Object.keys(pages)[0]] : null;
+}
+
+module.exports = {
+  fetchCircuitImage,
+};

--- a/test/wikipediaCircuitImageService.test.js
+++ b/test/wikipediaCircuitImageService.test.js
@@ -9,11 +9,11 @@ const serviceModulePath = require.resolve(
 const SUZUKA_URL =
   'https://en.wikipedia.org/wiki/Suzuka_International_Racing_Course';
 const SUZUKA_IMAGE_URL =
-  'https://upload.wikimedia.org/wikipedia/commons/e/ec/Suzuka_circuit_map--2005.svg';
+  'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Suzuka_circuit_map--2005.svg/1000px-Suzuka_circuit_map--2005.svg.png';
 const BARCELONA_URL =
   'https://en.wikipedia.org/wiki/Circuit_de_Barcelona-Catalunya';
 const BARCELONA_IMAGE_URL =
-  'https://upload.wikimedia.org/wikipedia/commons/2/26/Formula1_Circuit_Catalunya_2021.svg';
+  'https://upload.wikimedia.org/wikipedia/commons/thumb/2/26/Formula1_Circuit_Catalunya_2021.svg/1000px-Formula1_Circuit_Catalunya_2021.svg.png';
 const MONACO_URL = 'https://en.wikipedia.org/wiki/Circuit_de_Monaco';
 const MONACO_IMAGE_URL =
   'https://upload.wikimedia.org/wikipedia/commons/3/36/Monte_Carlo_Formula_1_track_map.svg';
@@ -78,7 +78,7 @@ test('returns the infobox image URL for a real circuit page URL', async () => {
       query: {
         pages: {
           1: {
-            imageinfo: [{ url: SUZUKA_IMAGE_URL }],
+            imageinfo: [{ thumburl: SUZUKA_IMAGE_URL }],
           },
         },
       },
@@ -107,7 +107,7 @@ test('falls back to track_map when the infobox image is missing', async () => {
       query: {
         pages: {
           1: {
-            imageinfo: [{ url: BARCELONA_IMAGE_URL }],
+            imageinfo: [{ thumburl: BARCELONA_IMAGE_URL }],
           },
         },
       },

--- a/test/wikipediaCircuitImageService.test.js
+++ b/test/wikipediaCircuitImageService.test.js
@@ -1,0 +1,182 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const telegramModulePath = require.resolve('../src/telegramService');
+const serviceModulePath = require.resolve(
+  '../src/wikipediaCircuitImageService',
+);
+
+const SUZUKA_URL =
+  'https://en.wikipedia.org/wiki/Suzuka_International_Racing_Course';
+const SUZUKA_IMAGE_URL =
+  'https://upload.wikimedia.org/wikipedia/commons/e/ec/Suzuka_circuit_map--2005.svg';
+const BARCELONA_URL =
+  'https://en.wikipedia.org/wiki/Circuit_de_Barcelona-Catalunya';
+const BARCELONA_IMAGE_URL =
+  'https://upload.wikimedia.org/wikipedia/commons/2/26/Formula1_Circuit_Catalunya_2021.svg';
+const MONACO_URL = 'https://en.wikipedia.org/wiki/Circuit_de_Monaco';
+const MONACO_IMAGE_URL =
+  'https://upload.wikimedia.org/wikipedia/commons/3/36/Monte_Carlo_Formula_1_track_map.svg';
+const RED_BULL_RING_URL = 'https://en.wikipedia.org/wiki/Red_Bull_Ring';
+
+delete require.cache[telegramModulePath];
+require.cache[telegramModulePath] = {
+  id: telegramModulePath,
+  filename: telegramModulePath,
+  loaded: true,
+  exports: {
+    sendTelegramMessage: async () => {},
+  },
+};
+delete require.cache[serviceModulePath];
+
+const { fetchCircuitImage } = require('../src/wikipediaCircuitImageService');
+
+function createJsonResponse(body, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    async json() {
+      return body;
+    },
+  };
+}
+
+function withMockedFetch(responses) {
+  const originalFetch = global.fetch;
+  const queue = [...responses];
+
+  global.fetch = async () => {
+    if (queue.length === 0) {
+      throw new Error('Unexpected extra fetch call');
+    }
+
+    const next = queue.shift();
+    if (next instanceof Error) {
+      throw next;
+    }
+
+    return next;
+  };
+
+  return () => {
+    global.fetch = originalFetch;
+    assert.equal(queue.length, 0, 'Not all mocked fetch responses were used');
+  };
+}
+
+test('returns the infobox image URL for a real circuit page URL', async () => {
+  const restore = withMockedFetch([
+    createJsonResponse({
+      parse: {
+        wikitext: {
+          '*': '| image = Suzuka circuit map--2005.svg',
+        },
+      },
+    }),
+    createJsonResponse({
+      query: {
+        pages: {
+          1: {
+            imageinfo: [{ url: SUZUKA_IMAGE_URL }],
+          },
+        },
+      },
+    }),
+  ]);
+
+  try {
+    const imageUrl = await fetchCircuitImage(SUZUKA_URL);
+
+    assert.equal(imageUrl, SUZUKA_IMAGE_URL);
+  } finally {
+    restore();
+  }
+});
+
+test('falls back to track_map when the infobox image is missing', async () => {
+  const restore = withMockedFetch([
+    createJsonResponse({
+      parse: {
+        wikitext: {
+          '*': '| track_map = [[File:Formula1 Circuit Catalunya 2021.svg|250px]]',
+        },
+      },
+    }),
+    createJsonResponse({
+      query: {
+        pages: {
+          1: {
+            imageinfo: [{ url: BARCELONA_IMAGE_URL }],
+          },
+        },
+      },
+    }),
+  ]);
+
+  try {
+    const imageUrl = await fetchCircuitImage(BARCELONA_URL);
+
+    assert.equal(imageUrl, BARCELONA_IMAGE_URL);
+  } finally {
+    restore();
+  }
+});
+
+test('falls back to the page thumbnail when the infobox has no usable image', async () => {
+  const restore = withMockedFetch([
+    createJsonResponse({
+      parse: {
+        wikitext: {
+          '*': '| location = Monaco',
+        },
+      },
+    }),
+    createJsonResponse({
+      query: {
+        pages: {
+          1: {
+            thumbnail: {
+              source: MONACO_IMAGE_URL,
+            },
+          },
+        },
+      },
+    }),
+  ]);
+
+  try {
+    const imageUrl = await fetchCircuitImage(MONACO_URL);
+
+    assert.equal(imageUrl, MONACO_IMAGE_URL);
+  } finally {
+    restore();
+  }
+});
+
+test('returns null when no circuit image can be resolved', async () => {
+  const restore = withMockedFetch([
+    createJsonResponse({
+      parse: {
+        wikitext: {
+          '*': '| location = Spielberg',
+        },
+      },
+    }),
+    createJsonResponse({
+      query: {
+        pages: {
+          1: {},
+        },
+      },
+    }),
+  ]);
+
+  try {
+    const imageUrl = await fetchCircuitImage(RED_BULL_RING_URL);
+
+    assert.equal(imageUrl, null);
+  } finally {
+    restore();
+  }
+});


### PR DESCRIPTION
## Summary
- extract circuit image fetching from src/f1DataService.js into a dedicated Wikipedia service
- select the correct circuit image from Wikipedia infobox fields with page thumbnail fallback and Telegram warning on failure
- return scaled Wikimedia thumbnail URLs for circuit files so Telegram gets PNG images instead of raw SVGs
- add service-level tests covering infobox image, track_map, thumbnail fallback, and null results

## Validation
- node --test test/wikipediaCircuitImageService.test.js
- npm run lint
- live-checked all 22 current season circuit Wikipedia URLs from Jolpi; all returned Telegram-safe PNG thumbnail URLs