### PR TITLE
Send next-race-info errors to the errors channel

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,10 @@
 require('dotenv').config();
 const { fetchAllF1Data } = require('./src/f1DataService');
 const { uploadJsonToBlob } = require('./src/azureBlobStorageService');
-const { sendTelegramMessage } = require('./src/telegramService');
+const {
+  sendTelegramMessage,
+  sendTelegramErrorMessage,
+} = require('./src/telegramService');
 
 async function main() {
   try {
@@ -20,7 +23,7 @@ async function main() {
     console.log(jsonString); // Log JSON to console
     console.log(`Race data uploaded to Azure Blob Storage as ${blobName}`);
   } catch (error) {
-    await sendTelegramMessage(
+    await sendTelegramErrorMessage(
       `❌ Failed to upload race data to Azure Blob Storage. Error: ${error.message}`,
     );
     console.error('Application error:', error);

--- a/src/telegramService.js
+++ b/src/telegramService.js
@@ -3,6 +3,7 @@
 const TelegramBot = require('node-telegram-bot-api');
 
 const LOG_CHANNEL_ID = '-1002298860617';
+const ERRORS_CHANNEL_ID = '-5167373779';
 const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 
 let bot = null;
@@ -14,7 +15,7 @@ if (TELEGRAM_BOT_TOKEN) {
 
 /**
  * Sends a message to a Telegram chat.
- * If the chat is the log channel, adds the NEXT_RACE_INFO prefix.
+ * If the chat is a channel, adds the NEXT_RACE_INFO prefix.
  * @param {string} messageText - The message to send.
  * @param {string} [chatIdOverride] - Optional chat ID to send to (defaults to LOG_CHANNEL_ID).
  * @returns {Promise<void>}
@@ -28,7 +29,9 @@ async function sendTelegramMessage(
     return;
   }
   let finalMessage = messageText;
-  if (chatIdOverride === LOG_CHANNEL_ID) {
+  const isChannelMessage =
+    chatIdOverride === LOG_CHANNEL_ID || chatIdOverride === ERRORS_CHANNEL_ID;
+  if (isChannelMessage) {
     finalMessage = 'NEXT_RACE_INFO: ' + messageText;
   }
   try {
@@ -38,4 +41,14 @@ async function sendTelegramMessage(
   }
 }
 
-module.exports = { sendTelegramMessage, LOG_CHANNEL_ID };
+async function sendTelegramErrorMessage(messageText) {
+  await sendTelegramMessage(messageText, LOG_CHANNEL_ID);
+  await sendTelegramMessage(messageText, ERRORS_CHANNEL_ID);
+}
+
+module.exports = {
+  sendTelegramMessage,
+  sendTelegramErrorMessage,
+  LOG_CHANNEL_ID,
+  ERRORS_CHANNEL_ID,
+};

--- a/src/wikipediaCircuitImageService.js
+++ b/src/wikipediaCircuitImageService.js
@@ -1,6 +1,6 @@
 const WIKIPEDIA_API_BASE = 'https://en.wikipedia.org/w/api.php';
 const CIRCUIT_IMAGE_WIDTH = '1000';
-const { sendTelegramMessage } = require('./telegramService');
+const { sendTelegramErrorMessage } = require('./telegramService');
 
 async function fetchCircuitImage(wikipediaUrl) {
   if (!wikipediaUrl) return null;
@@ -35,7 +35,7 @@ async function fetchCircuitImage(wikipediaUrl) {
 }
 
 async function notifyCircuitImageFetchFailure(wikipediaUrl, reason) {
-  await sendTelegramMessage(
+  await sendTelegramErrorMessage(
     `Warning: Failed to fetch circuit image URL for ${wikipediaUrl}. Reason: ${reason}`,
   );
 }


### PR DESCRIPTION
## Summary
- add  to the Telegram service
- prefix messages sent to both Telegram channels consistently
- send upload failure notifications to both the log and errors channels

## Verification
- npx eslint index.js src/telegramService.js