### PR TITLE
ci: add deploy-infra workflow for ACI

### DIFF
--- a/.github/workflows/deploy-aci.yml
+++ b/.github/workflows/deploy-aci.yml
@@ -1,17 +1,12 @@
-name: Deploy Infra
+name: Deploy ACI
 
 on:
   push:
     branches: ['main']
     paths:
       - 'infra/aci/**'
-      - '.github/workflows/deploy-infra.yml'
+      - '.github/workflows/deploy-aci.yml'
   workflow_dispatch:
-    inputs:
-      deploy_aci:
-        description: 'Deploy ACI (restarts container in prod)'
-        type: boolean
-        default: true
 
 permissions:
   id-token: write
@@ -28,7 +23,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Azure login
-        if: github.event_name == 'push' || inputs.deploy_aci
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -36,5 +30,4 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy ACI
-        if: github.event_name == 'push' || inputs.deploy_aci
         run: npm run deploy:aci

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -4,10 +4,14 @@ on:
   push:
     branches: ['main']
     paths:
-      - 'infra/**'
-      - 'package.json'
+      - 'infra/aci/**'
       - '.github/workflows/deploy-infra.yml'
   workflow_dispatch:
+    inputs:
+      deploy_aci:
+        description: 'Deploy ACI (restarts container in prod)'
+        type: boolean
+        default: true
 
 permissions:
   id-token: write
@@ -24,6 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Azure login
+        if: github.event_name == 'push' || inputs.deploy_aci
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -31,4 +36,5 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy ACI
+        if: github.event_name == 'push' || inputs.deploy_aci
         run: npm run deploy:aci

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -1,0 +1,34 @@
+name: Deploy Infra
+
+on:
+  push:
+    branches: ['main']
+    paths:
+      - 'infra/**'
+      - 'package.json'
+      - '.github/workflows/deploy-infra.yml'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      RESOURCE_GROUP: f1-fantazy-bot
+      DEPLOYMENT_SUFFIX: ${{ github.run_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy ACI
+        run: npm run deploy:aci

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "start": "node index.js",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "deploy:aci": "az deployment group create --resource-group f1-fantazy-bot --name \"next-race-aci-${DEPLOYMENT_SUFFIX:-manual-$(date +%s)}\" --template-file infra/aci/azuredeploy.json --parameters @infra/aci/azuredeploy.parameters.json --output none --only-show-errors"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
Mirrors the auto-deploy pattern from the other F1 repos.

## Changes
- **`.github/workflows/deploy-infra.yml`** — new workflow. Triggers on push to `main` (and `workflow_dispatch`) when `infra/**`, `package.json`, or the workflow itself changes. Uses Azure OIDC login (reuses existing `AZURE_*` secrets).
- **`package.json`** — added `deploy:aci` script with traceable `--name "next-race-aci-${DEPLOYMENT_SUFFIX:-manual-$(date +%s)}"` and quiet output flags (`--output none --only-show-errors`).

No runner/scheduler Logic App in this repo, so no grant-runner-msi step is needed.