### PR TITLE
Add ARM template for Logic App that triggers the ACI

### DIFF
--- a/.github/workflows/deploy-logicapp.yml
+++ b/.github/workflows/deploy-logicapp.yml
@@ -1,0 +1,33 @@
+name: Deploy Logic App
+
+on:
+  push:
+    branches: ['main']
+    paths:
+      - 'infra/logicapp/**'
+      - '.github/workflows/deploy-logicapp.yml'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      RESOURCE_GROUP: f1-fantazy-bot
+      DEPLOYMENT_SUFFIX: ${{ github.run_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy Logic App
+        run: npm run deploy:logicapp

--- a/.github/workflows/deploy-logicapps.yml
+++ b/.github/workflows/deploy-logicapps.yml
@@ -1,11 +1,11 @@
-name: Deploy Logic App
+name: Deploy Logic Apps
 
 on:
   push:
     branches: ['main']
     paths:
       - 'infra/logicapp/**'
-      - '.github/workflows/deploy-logicapp.yml'
+      - '.github/workflows/deploy-logicapps.yml'
   workflow_dispatch:
 
 permissions:
@@ -29,5 +29,5 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Deploy Logic App
-        run: npm run deploy:logicapp
+      - name: Deploy Logic Apps
+        run: npm run deploy:logicapps

--- a/infra/logicapp/azuredeploy.json
+++ b/infra/logicapp/azuredeploy.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "logicAppName": {
+      "type": "string",
+      "defaultValue": "f1-fantasy-next-race-info-runner",
+      "metadata": {
+        "description": "Name of the Logic App workflow that triggers the ACI container group."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for the Logic App and the managed API connection."
+      }
+    },
+    "aciConnectionName": {
+      "type": "string",
+      "defaultValue": "aci-1",
+      "metadata": {
+        "description": "Name of the managed API connection to Azure Container Instance."
+      }
+    },
+    "aciConnectionDisplayName": {
+      "type": "string",
+      "defaultValue": "aci-connection",
+      "metadata": {
+        "description": "Display name for the ACI managed API connection."
+      }
+    },
+    "containerGroupName": {
+      "type": "string",
+      "defaultValue": "f1-fantasy-next-race-info-aci",
+      "metadata": {
+        "description": "Name of the Azure Container Instance container group that will be started by the Logic App."
+      }
+    },
+    "containerGroupResourceGroup": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().name]",
+      "metadata": {
+        "description": "Resource group that contains the ACI container group."
+      }
+    },
+    "containerGroupSubscriptionId": {
+      "type": "string",
+      "defaultValue": "[subscription().subscriptionId]",
+      "metadata": {
+        "description": "Subscription id that contains the ACI container group."
+      }
+    },
+    "recurrenceFrequency": {
+      "type": "string",
+      "defaultValue": "Week",
+      "allowedValues": ["Second", "Minute", "Hour", "Day", "Week", "Month"],
+      "metadata": {
+        "description": "Recurrence frequency for the Logic App trigger."
+      }
+    },
+    "recurrenceInterval": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "Recurrence interval for the Logic App trigger."
+      }
+    },
+    "recurrenceHours": {
+      "type": "array",
+      "defaultValue": [0],
+      "metadata": {
+        "description": "Hours of the day at which the Logic App should run."
+      }
+    },
+    "recurrenceWeekDays": {
+      "type": "array",
+      "defaultValue": ["Monday"],
+      "metadata": {
+        "description": "Days of the week on which the Logic App should run (used when frequency is Week)."
+      }
+    },
+    "recurrenceTimeZone": {
+      "type": "string",
+      "defaultValue": "UTC",
+      "metadata": {
+        "description": "Time zone used to evaluate the recurrence schedule."
+      }
+    }
+  },
+  "variables": {
+    "aciManagedApiId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', parameters('location'), '/managedApis/aci')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/connections",
+      "apiVersion": "2016-06-01",
+      "name": "[parameters('aciConnectionName')]",
+      "location": "[parameters('location')]",
+      "kind": "V1",
+      "properties": {
+        "displayName": "[parameters('aciConnectionDisplayName')]",
+        "parameterValueType": "Alternative",
+        "alternativeParameterValues": {},
+        "customParameterValues": {},
+        "api": {
+          "id": "[variables('aciManagedApiId')]"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Logic/workflows",
+      "apiVersion": "2019-05-01",
+      "name": "[parameters('logicAppName')]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/connections', parameters('aciConnectionName'))]"
+      ],
+      "properties": {
+        "state": "Enabled",
+        "definition": {
+          "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "$connections": {
+              "type": "Object",
+              "defaultValue": {}
+            }
+          },
+          "triggers": {
+            "Recurrence": {
+              "type": "Recurrence",
+              "recurrence": {
+                "frequency": "[parameters('recurrenceFrequency')]",
+                "interval": "[parameters('recurrenceInterval')]",
+                "timeZone": "[parameters('recurrenceTimeZone')]",
+                "schedule": {
+                  "hours": "[parameters('recurrenceHours')]",
+                  "weekDays": "[parameters('recurrenceWeekDays')]"
+                }
+              }
+            }
+          },
+          "actions": {
+            "Start_containers_in_a_container_group": {
+              "type": "ApiConnection",
+              "runAfter": {},
+              "inputs": {
+                "host": {
+                  "connection": {
+                    "name": "@parameters('$connections')['aci']['connectionId']"
+                  }
+                },
+                "method": "post",
+                "path": "[concat('/subscriptions/@{encodeURIComponent(''', parameters('containerGroupSubscriptionId'), ''')}/resourceGroups/@{encodeURIComponent(''', parameters('containerGroupResourceGroup'), ''')}/providers/Microsoft.ContainerInstance/containerGroups/@{encodeURIComponent(''', parameters('containerGroupName'), ''')}/start')]",
+                "queries": {
+                  "x-ms-api-version": "2023-05-01"
+                }
+              }
+            }
+          },
+          "outputs": {}
+        },
+        "parameters": {
+          "$connections": {
+            "value": {
+              "aci": {
+                "connectionId": "[resourceId('Microsoft.Web/connections', parameters('aciConnectionName'))]",
+                "connectionName": "[parameters('aciConnectionName')]",
+                "id": "[variables('aciManagedApiId')]",
+                "connectionProperties": {
+                  "authentication": {
+                    "type": "ManagedServiceIdentity"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "logicAppResourceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Logic/workflows', parameters('logicAppName'))]"
+    },
+    "logicAppPrincipalId": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Logic/workflows', parameters('logicAppName')), '2019-05-01', 'full').identity.principalId]"
+    },
+    "aciConnectionResourceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Web/connections', parameters('aciConnectionName'))]"
+    }
+  }
+}

--- a/infra/logicapp/azuredeploy.parameters.json
+++ b/infra/logicapp/azuredeploy.parameters.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "logicAppName": {
+      "value": "f1-fantasy-next-race-info-runner"
+    },
+    "location": {
+      "value": "westeurope"
+    },
+    "aciConnectionName": {
+      "value": "aci-1"
+    },
+    "aciConnectionDisplayName": {
+      "value": "aci-connection"
+    },
+    "containerGroupName": {
+      "value": "f1-fantasy-next-race-info-aci"
+    },
+    "containerGroupResourceGroup": {
+      "value": "f1-fantazy-bot"
+    },
+    "containerGroupSubscriptionId": {
+      "value": "5cfc4033-d828-4bdb-b9ea-de042e483715"
+    },
+    "recurrenceFrequency": {
+      "value": "Week"
+    },
+    "recurrenceInterval": {
+      "value": 1
+    },
+    "recurrenceHours": {
+      "value": [0]
+    },
+    "recurrenceWeekDays": {
+      "value": ["Monday"]
+    },
+    "recurrenceTimeZone": {
+      "value": "UTC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint:fix": "eslint . --fix",
     "start": "node index.js",
     "format": "prettier --write .",
-    "deploy:aci": "az deployment group create --resource-group f1-fantazy-bot --name \"next-race-aci-${DEPLOYMENT_SUFFIX:-manual-$(date +%s)}\" --template-file infra/aci/azuredeploy.json --parameters @infra/aci/azuredeploy.parameters.json --output none --only-show-errors"
+    "deploy:aci": "az deployment group create --resource-group f1-fantazy-bot --name \"next-race-aci-${DEPLOYMENT_SUFFIX:-manual-$(date +%s)}\" --template-file infra/aci/azuredeploy.json --parameters @infra/aci/azuredeploy.parameters.json --output none --only-show-errors",
+    "deploy:logicapp": "az deployment group create --resource-group f1-fantazy-bot --name \"next-race-logicapp-${DEPLOYMENT_SUFFIX:-manual-$(date +%s)}\" --template-file infra/logicapp/azuredeploy.json --parameters @infra/logicapp/azuredeploy.parameters.json"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "node index.js",
     "format": "prettier --write .",
     "deploy:aci": "az deployment group create --resource-group f1-fantazy-bot --name \"next-race-aci-${DEPLOYMENT_SUFFIX:-manual-$(date +%s)}\" --template-file infra/aci/azuredeploy.json --parameters @infra/aci/azuredeploy.parameters.json --output none --only-show-errors",
-    "deploy:logicapp": "az deployment group create --resource-group f1-fantazy-bot --name \"next-race-logicapp-${DEPLOYMENT_SUFFIX:-manual-$(date +%s)}\" --template-file infra/logicapp/azuredeploy.json --parameters @infra/logicapp/azuredeploy.parameters.json"
+    "deploy:logicapps": "az deployment group create --resource-group f1-fantazy-bot --name \"next-race-logicapp-${DEPLOYMENT_SUFFIX:-manual-$(date +%s)}\" --template-file infra/logicapp/azuredeploy.json --parameters @infra/logicapp/azuredeploy.parameters.json --output none --only-show-errors"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## Summary

Adds an ARM template that captures the existing `f1-fantasy-next-race-info-runner` Logic App (which starts the ACI container group on a weekly schedule) so it lives in source control alongside the existing `infra/aci/` template.

## What's deployed

- **`Microsoft.Web/connections/aci-1`** — managed API connection to Azure Container Instance (ManagedServiceIdentity auth).
- **`Microsoft.Logic/workflows/f1-fantasy-next-race-info-runner`** — Logic App with:
  - System-assigned managed identity
  - Weekly `Recurrence` trigger (Mondays at 00:00 UTC by default, all parameterized)
  - `Start_containers_in_a_container_group` action that POSTs to the ACI `/start` endpoint
  - `$connections` wired to `aci-1` via MSI

## Files

- `infra/logicapp/azuredeploy.json`
- `infra/logicapp/azuredeploy.parameters.json` (defaults mirror the live resource)

## Validation

- `az deployment group validate` ✅
- `az deployment group what-if` shows **NoChange** on the connection and only a read-only `evaluatedRecurrence` runtime field diff on the Logic App — i.e. template matches the live resource.

## Notes

- No secrets flow through this template (no `secureString` params, no Key Vault refs, MSI-based auth), so `--output none --only-show-errors` flags are not required at deploy time.