### PR TITLE
Add scheduler Logic App ARM template, MSI grant script, and deploy workflow

### DIFF
--- a/.github/workflows/deploy-logicapps.yml
+++ b/.github/workflows/deploy-logicapps.yml
@@ -1,0 +1,34 @@
+name: Deploy Logic Apps
+
+on:
+  push:
+    branches: ['main']
+    paths:
+      - 'infra/scheduler/**'
+      - 'scripts/grant-runner-msi.sh'
+      - '.github/workflows/deploy-logicapps.yml'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      RESOURCE_GROUP: f1-fantazy-bot
+      DEPLOYMENT_SUFFIX: ${{ github.run_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy scheduler Logic App (+ grant MSI)
+        run: npm run deploy:logicapps

--- a/infra/scheduler/azuredeploy.json
+++ b/infra/scheduler/azuredeploy.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "logicAppName": {
+      "type": "string",
+      "defaultValue": "f1-fantasy-next-race-info-scheduler",
+      "metadata": {
+        "description": "Name of the scheduler Logic App resource."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for the Logic App."
+      }
+    },
+    "subscriptionId": {
+      "type": "string",
+      "metadata": {
+        "description": "Azure subscription ID where the ACI resource lives."
+      }
+    },
+    "aciResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "Resource group containing the ACI container group."
+      }
+    },
+    "containerGroupName": {
+      "type": "string",
+      "defaultValue": "f1-fantasy-next-race-info-aci",
+      "metadata": {
+        "description": "Name of the ACI container group to start."
+      }
+    }
+  },
+  "variables": {
+    "aciStartUri": "[concat('https://management.azure.com/subscriptions/', parameters('subscriptionId'), '/resourceGroups/', parameters('aciResourceGroup'), '/providers/Microsoft.ContainerInstance/containerGroups/', parameters('containerGroupName'), '/start?api-version=2023-05-01')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Logic/workflows",
+      "apiVersion": "2019-05-01",
+      "name": "[parameters('logicAppName')]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "state": "Enabled",
+        "definition": {
+          "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+          "contentVersion": "1.0.0.0",
+          "triggers": {
+            "Every_Monday": {
+              "type": "Recurrence",
+              "recurrence": {
+                "frequency": "Week",
+                "interval": 1,
+                "schedule": {
+                  "weekDays": ["Monday"],
+                  "hours": [0],
+                  "minutes": [0]
+                },
+                "timeZone": "UTC"
+              }
+            }
+          },
+          "actions": {
+            "Start_ACI": {
+              "type": "Http",
+              "inputs": {
+                "method": "POST",
+                "uri": "[variables('aciStartUri')]",
+                "authentication": {
+                  "type": "ManagedServiceIdentity",
+                  "audience": "https://management.azure.com/"
+                }
+              },
+              "runAfter": {}
+            }
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "logicAppResourceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Logic/workflows', parameters('logicAppName'))]"
+    },
+    "logicAppPrincipalId": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Logic/workflows', parameters('logicAppName')), '2019-05-01', 'Full').identity.principalId]",
+      "metadata": {
+        "description": "Assign this principal Contributor role on the ACI resource scope."
+      }
+    }
+  }
+}

--- a/infra/scheduler/azuredeploy.parameters.json
+++ b/infra/scheduler/azuredeploy.parameters.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "logicAppName": {
+      "value": "f1-fantasy-next-race-info-scheduler"
+    },
+    "location": {
+      "value": "westeurope"
+    },
+    "subscriptionId": {
+      "value": "5cfc4033-d828-4bdb-b9ea-de042e483715"
+    },
+    "aciResourceGroup": {
+      "value": "f1-fantazy-bot"
+    },
+    "containerGroupName": {
+      "value": "f1-fantasy-next-race-info-aci"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "lint:fix": "eslint . --fix",
     "start": "node index.js",
     "format": "prettier --write .",
-    "deploy:aci": "az deployment group create --resource-group f1-fantazy-bot --name \"next-race-aci-${DEPLOYMENT_SUFFIX:-manual-$(date +%s)}\" --template-file infra/aci/azuredeploy.json --parameters @infra/aci/azuredeploy.parameters.json --output none --only-show-errors"
+    "deploy:aci": "az deployment group create --resource-group f1-fantazy-bot --name \"next-race-aci-${DEPLOYMENT_SUFFIX:-manual-$(date +%s)}\" --template-file infra/aci/azuredeploy.json --parameters @infra/aci/azuredeploy.parameters.json --output none --only-show-errors",
+    "deploy:scheduler": "az deployment group create --resource-group f1-fantazy-bot --name \"next-race-scheduler-${DEPLOYMENT_SUFFIX:-manual-$(date +%s)}\" --template-file infra/scheduler/azuredeploy.json --parameters @infra/scheduler/azuredeploy.parameters.json --output none --only-show-errors",
+    "deploy:grant-runner-msi": "bash scripts/grant-runner-msi.sh",
+    "deploy:logicapps": "npm run deploy:scheduler && npm run deploy:grant-runner-msi"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/scripts/grant-runner-msi.sh
+++ b/scripts/grant-runner-msi.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Grants the scheduler Logic App's system-assigned MSI Contributor on the ACI.
+# The scheduler Logic App calls the ACI /start endpoint via ManagedServiceIdentity
+# auth, so it needs Contributor on the ACI scope.
+# Idempotent — skips if the role assignment already exists.
+#
+# Usage:
+#   RESOURCE_GROUP=f1-fantazy-bot ACI_NAME=f1-fantasy-next-race-info-aci \
+#     bash scripts/grant-runner-msi.sh
+
+set -euo pipefail
+
+RESOURCE_GROUP="${RESOURCE_GROUP:-f1-fantazy-bot}"
+ACI_NAME="${ACI_NAME:-f1-fantasy-next-race-info-aci}"
+LOGIC_APP_NAME="${LOGIC_APP_NAME:-f1-fantasy-next-race-info-scheduler}"
+
+SUBSCRIPTION_ID="$(az account show --query id -o tsv)"
+
+PRINCIPAL_ID="$(az resource show \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$LOGIC_APP_NAME" \
+  --resource-type Microsoft.Logic/workflows \
+  --query identity.principalId -o tsv)"
+
+if [ -z "$PRINCIPAL_ID" ] || [ "$PRINCIPAL_ID" = "null" ]; then
+  echo "Could not resolve principalId for $LOGIC_APP_NAME — is it deployed with a system-assigned identity?" >&2
+  exit 1
+fi
+
+SCOPE="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.ContainerInstance/containerGroups/$ACI_NAME"
+
+existing="$(az role assignment list \
+  --assignee "$PRINCIPAL_ID" \
+  --role Contributor \
+  --scope "$SCOPE" \
+  --query "length(@)" -o tsv)"
+
+if [ "$existing" -gt 0 ]; then
+  echo "Role assignment already exists — skipping."
+else
+  az role assignment create \
+    --assignee-object-id "$PRINCIPAL_ID" \
+    --assignee-principal-type ServicePrincipal \
+    --role Contributor \
+    --scope "$SCOPE"
+  echo "Granted Contributor on $ACI_NAME to $PRINCIPAL_ID."
+fi


### PR DESCRIPTION
## Summary

Brings this repo in line with the `infra/scheduler` + HTTP/MSI pattern used across the other F1 repos (`f1-fantasy-api-data`, `f1-fantasy-live-score`, `f1-fantasy-scraper`), replacing the current managed-connector-based `f1-fantasy-next-race-info-runner` Logic App with a simpler HTTP+MSI scheduler.

## What's added

- **`infra/scheduler/azuredeploy.json`** — Logic App `f1-fantasy-next-race-info-scheduler` with:
  - System-assigned managed identity
  - Weekly Monday 00:00 UTC `Recurrence` trigger
  - Single `Start_ACI` Http action that POSTs to `…/containerGroups/{name}/start?api-version=2023-05-01` using `ManagedServiceIdentity` auth
  - No `Microsoft.Web/connections` resource (drops the `aci-1` managed connector)
- **`infra/scheduler/azuredeploy.parameters.json`** — parameters mirroring the existing `f1-fantazy-bot` RG / ACI.
- **`scripts/grant-runner-msi.sh`** — idempotent helper that grants the Logic App MSI `Contributor` on the ACI scope (copied from the sibling repos).
- **`.github/workflows/deploy-logicapps.yml`** — auto-deploys on pushes to `main` that touch `infra/scheduler/**`, `scripts/grant-runner-msi.sh`, or the workflow file (and on `workflow_dispatch`). Uses OIDC `azure/login` and runs `npm run deploy:logicapps`.
- **`package.json`** — new scripts:
  - `deploy:scheduler` — ARM deploy for the Logic App
  - `deploy:grant-runner-msi` — runs the bash helper
  - `deploy:logicapps` — orchestrates `deploy:scheduler && deploy:grant-runner-msi`
  - All `deploy:*` scripts now uniformly use `--output none --only-show-errors`

## Migration note

After merging and the first deploy, the existing **`f1-fantasy-next-race-info-runner`** Logic App and the **`aci-1`** managed API connection become unused and can be deleted manually:

```bash
az resource delete --resource-group f1-fantazy-bot --name f1-fantasy-next-race-info-runner --resource-type Microsoft.Logic/workflows
az resource delete --resource-group f1-fantazy-bot --name aci-1 --resource-type Microsoft.Web/connections
```

## Validation

- `az deployment group validate` ✅