### PR TITLE
Secure Telegram bot token in Logic App notify actions

### DIFF
--- a/infra/scheduler/azuredeploy.json
+++ b/infra/scheduler/azuredeploy.json
@@ -59,6 +59,9 @@
         "definition": {
           "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
           "contentVersion": "1.0.0.0",
+          "parameters": {
+            "telegramBotToken": { "type": "SecureString" }
+          },
           "triggers": {
             "Every_Monday": {
               "type": "Recurrence",
@@ -97,12 +100,15 @@
               "type": "Http",
               "inputs": {
                 "method": "POST",
-                "uri": "[concat('https://api.telegram.org/bot', parameters('telegramBotToken'), '/sendMessage')]",
+                "uri": "@{concat('https://api.telegram.org/bot', parameters('telegramBotToken'), '/sendMessage')}",
                 "headers": { "Content-Type": "application/json" },
                 "body": {
                   "chat_id": -1002298860617,
                   "text": "@{concat('🚨 Logic App ', workflow().name, ' failed\n\nRun: ', workflow().run.name, '\nTime (UTC): ', utcNow(), '\n\nFailed actions:\n', take(string(filter(result('Try'), equals(item()?['status'], 'Failed'))), 3500))}"
                 }
+              },
+              "runtimeConfiguration": {
+                "secureData": { "properties": ["inputs", "outputs"] }
               },
               "runAfter": {
                 "Try": ["Failed", "TimedOut"]
@@ -112,17 +118,25 @@
               "type": "Http",
               "inputs": {
                 "method": "POST",
-                "uri": "[concat('https://api.telegram.org/bot', parameters('telegramBotToken'), '/sendMessage')]",
+                "uri": "@{concat('https://api.telegram.org/bot', parameters('telegramBotToken'), '/sendMessage')}",
                 "headers": { "Content-Type": "application/json" },
                 "body": {
                   "chat_id": -5167373779,
                   "text": "@{concat('🚨 Logic App ', workflow().name, ' failed\n\nRun: ', workflow().run.name, '\nTime (UTC): ', utcNow(), '\n\nFailed actions:\n', take(string(filter(result('Try'), equals(item()?['status'], 'Failed'))), 3500))}"
                 }
               },
+              "runtimeConfiguration": {
+                "secureData": { "properties": ["inputs", "outputs"] }
+              },
               "runAfter": {
                 "Try": ["Failed", "TimedOut"]
               }
             }
+          }
+        },
+        "parameters": {
+          "telegramBotToken": {
+            "value": "[parameters('telegramBotToken')]"
           }
         }
       }


### PR DESCRIPTION
# Secure Telegram bot token in Logic App notify actions

## Problem

In the previous PR (adding Telegram failure notifications to the Logic Apps), the notify HTTP action URIs used an ARM template expression:

```json
"uri": "[concat('https://api.telegram.org/bot', parameters('telegramBotToken'), '/sendMessage')]"
```

ARM resolves `[concat(...)]` at **deployment time**, so the fully-resolved URL (with the literal bot token) gets baked into the deployed workflow definition JSON. That means the token is:

- Visible to anyone with read access to the Logic App via portal / ARM GET on the workflow definition.
- Written into every run's action inputs/outputs in run history.

Effectively a plaintext secret exposure.

## Fix

Two layers of defense.

### 1. Use a workflow-level `SecureString` parameter (runtime resolution)

The Logic Apps engine masks `SecureString` workflow parameter values (`*****`) in the definition and hides them in run history.

Per workflow:

- Inside `definition`:
  ```json
  "parameters": { "telegramBotToken": { "type": "SecureString" } }
  ```
- At the workflow resource `properties` level (sibling of `definition`):
  ```json
  "parameters": {
    "telegramBotToken": { "value": "[parameters('telegramBotToken')]" }
  }
  ```
- Notify URIs change from ARM `[concat(...)]` (deploy-time) to workflow `@{concat(...)}` (runtime):
  ```json
  "uri": "@{concat('https://api.telegram.org/bot', parameters('telegramBotToken'), '/sendMessage')}"
  ```

### 2. Scrub action inputs/outputs from run history

On both `Notify_*_On_Failure` actions:

```json
"runtimeConfiguration": {
  "secureData": { "properties": ["inputs", "outputs"] }
}
```

## No change to parameters files

The ARM template parameter still sources the token from the existing Key Vault secret (`telegram-bot-token` in `f1-fantasy-kv`). No new resources, no RBAC changes.

## Follow-up (not in this PR)

A stronger option is to let each Logic App fetch the token from Key Vault at runtime using a managed identity. That would keep the token entirely out of the ARM deployment pipeline. It requires every Logic App to have a `SystemAssigned` identity and a per-Logic-App RBAC grant on the vault; worth a separate PR if we want that extra hardening.
