### PR TITLE
Fix Logic App notify action: replace ARM-only filter() function

### DIFF
--- a/infra/scheduler/azuredeploy.json
+++ b/infra/scheduler/azuredeploy.json
@@ -104,7 +104,7 @@
                 "headers": { "Content-Type": "application/json" },
                 "body": {
                   "chat_id": -1002298860617,
-                  "text": "@{concat('🚨 Logic App ', workflow().name, ' failed\n\nRun: ', workflow().run.name, '\nTime (UTC): ', utcNow(), '\n\nFailed actions:\n', take(string(filter(result('Try'), equals(item()?['status'], 'Failed'))), 3500))}"
+                  "text": "@{concat('🚨 Logic App ', workflow().name, ' failed\n\nRun: ', workflow().run.name, '\nTime (UTC): ', utcNow(), '\n\nFailed actions:\n', take(string(result('Try')), 3500))}"
                 }
               },
               "runtimeConfiguration": {
@@ -122,7 +122,7 @@
                 "headers": { "Content-Type": "application/json" },
                 "body": {
                   "chat_id": -5167373779,
-                  "text": "@{concat('🚨 Logic App ', workflow().name, ' failed\n\nRun: ', workflow().run.name, '\nTime (UTC): ', utcNow(), '\n\nFailed actions:\n', take(string(filter(result('Try'), equals(item()?['status'], 'Failed'))), 3500))}"
+                  "text": "@{concat('🚨 Logic App ', workflow().name, ' failed\n\nRun: ', workflow().run.name, '\nTime (UTC): ', utcNow(), '\n\nFailed actions:\n', take(string(result('Try')), 3500))}"
                 }
               },
               "runtimeConfiguration": {


### PR DESCRIPTION
# Fix Logic App notify action: replace ARM-only `filter()` function

## Bug

After deploying the previous security PR, triggering a Logic App failure produced **no** Telegram message. The run history showed the notify step itself failing:

> InvalidTemplate — Unable to process template language expressions in action `Notify_Errors_Channel_On_Failure` inputs at line '0' and column '0': `'The template function 'filter' is not defined or not valid.'`

## Root cause

`filter()` is an **ARM template** function. The **Logic App Workflow Definition Language** (WDL) — which is what `@{…}` runtime expressions use — does not provide a `filter()` function, so this expression blew up at runtime:

```
@{concat(…, take(string(filter(result('Try'), equals(item()?['status'], 'Failed'))), 3500))}
```

## Fix

Drop the filter and just stringify `result('Try')` directly:

```
@{concat(…, take(string(result('Try')), 3500))}
```

- Still truncated to 3500 chars, so we stay well under Telegram's 4096 message limit.
- The notify action only runs when the `Try` scope is `Failed` or `TimedOut`, so failed actions are still the relevant content of the message — we just also include the successful actions from the same Try scope.

No other changes. Validated with `python3 -m json.tool` on every modified ARM template.
