### PR TITLE
Update Azure OpenAI model to gpt-5.4

### DIFF
--- a/infra/aci/azuredeploy.json
+++ b/infra/aci/azuredeploy.json
@@ -98,7 +98,7 @@
     },
     "azureOpenAiModel": {
       "type": "string",
-      "defaultValue": "gpt-5-chat",
+      "defaultValue": "gpt-5.4",
       "metadata": {
         "description": "Azure OpenAI deployment/model name."
       }

--- a/infra/aci/azuredeploy.parameters.json
+++ b/infra/aci/azuredeploy.parameters.json
@@ -30,7 +30,7 @@
       "value": "f1-fantasy-scraper-json"
     },
     "azureOpenAiModel": {
-      "value": "gpt-5.3-chat"
+      "value": "gpt-5.4"
     },
     "acrPassword": {
       "reference": {


### PR DESCRIPTION
## Summary
- Update the Azure OpenAI ARM template default model to `gpt-5.4`
- Update the checked-in ACI deployment parameters model value to `gpt-5.4`

## Validation
- Parsed both ARM JSON files successfully
- Pre-commit hook ran lint and Prettier during commit