### PR TITLE
Upgrade Azure OpenAI deployment to gpt-5.6-terra

### DIFF
--- a/infra/aci/azuredeploy.json
+++ b/infra/aci/azuredeploy.json
@@ -98,7 +98,7 @@
     },
     "azureOpenAiModel": {
       "type": "string",
-      "defaultValue": "gpt-5.4",
+      "defaultValue": "gpt-5.6-terra",
       "metadata": {
         "description": "Azure OpenAI deployment/model name."
       }

--- a/infra/aci/azuredeploy.parameters.json
+++ b/infra/aci/azuredeploy.parameters.json
@@ -30,7 +30,7 @@
       "value": "f1-fantasy-scraper-json"
     },
     "azureOpenAiModel": {
-      "value": "gpt-5.4"
+      "value": "gpt-5.6-terra"
     },
     "acrPassword": {
       "reference": {


### PR DESCRIPTION
## Summary

- update the Azure deployment template default to gpt-5.6-terra
- update the checked-in deployment parameter to gpt-5.6-terra
- leave OpenAI reasoning effort unspecified for this standalone service

## Validation

- npm run lint
- JSON parsing for both modified deployment files
- node --check src/azureOpenAiService.js
- git diff --check